### PR TITLE
feat(bttv): add `broadcast_me` and `emote_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
- - Add BTTV live emote update tests. (#33)
+ - Add BTTV live emote update tests. (#33, #34)
 
 ## v1.0.5
 

--- a/internal/routes/liveupdates/bttv/basic.go
+++ b/internal/routes/liveupdates/bttv/basic.go
@@ -12,12 +12,30 @@ import (
 
 const (
 	addEmoteFormatString    = `{"data":{"channel":"%s","emote":{"channel":"emjaykae","code":"PepePls","id":"55898e122612142e6aaa935b","imageType":"gif","url":"https://cdn.betterttv.net/emote/55898e122612142e6aaa935b/1x","urlTemplate":"https://cdn.betterttv.net/emote/55898e122612142e6aaa935b/{{image}}","user":{"displayName":"EmJayKae","id":"5537fb2b236a1aa17a9970df","name":"emjaykae","providerId":"23473656"}}},"name":"emote_create"}`
+	updateEmoteFormatString = `{"data":{"channel":"%s","emote":{"code":"PepePls","id":"55898e122612142e6aaa935b"}},"name":"emote_update"}`
 	removeEmoteFormstString = `{"data":{"channel":"%s","emoteId":"55898e122612142e6aaa935b"},"name":"emote_delete"}`
 )
 
 func AllEvents(c *websocket.Conn, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 1*time.Second)
 	defer cancel()
+
+	// Invariant: The update message is only sent,
+	//            once the "broadcast_me" message was received.
+	receivedBroadcastMe := false
+	sentBroadcastMe := false
+	trySendUpdate := func(channel string) bool {
+		if !receivedBroadcastMe || sentBroadcastMe {
+			return true
+		}
+		sentBroadcastMe = true
+		formatted := []byte(fmt.Sprintf(updateEmoteFormatString, channel))
+		if err := c.Write(ctx, websocket.MessageText, formatted); err != nil {
+			log.Println("Failed to send", err)
+			return false
+		}
+		return true
+	}
 
 	for {
 		msg, ok := DefaultRead(ctx, c, r)
@@ -37,12 +55,22 @@ func AllEvents(c *websocket.Conn, r *http.Request) {
 				log.Println("Failed to send", err)
 				break
 			}
+			if !trySendUpdate(payload.Data.Name) {
+				break
+			}
 			formatted = []byte(fmt.Sprintf(removeEmoteFormstString, payload.Data.Name))
 			if err := c.Write(ctx, websocket.MessageText, formatted); err != nil {
 				log.Println("Failed to send", err)
 				// break
 			}
-
+		case "broadcast_me":
+			receivedBroadcastMe = true
+			payload, err := ConvertMessage[BroadcastMePayload](msg)
+			if err != nil {
+				log.Println("Bad message", err)
+				break
+			}
+			trySendUpdate(payload.Data.Channel)
 		default:
 			log.Println("Unhandled message:", msg)
 		}

--- a/internal/routes/liveupdates/bttv/messages.go
+++ b/internal/routes/liveupdates/bttv/messages.go
@@ -3,7 +3,7 @@ package bttv
 import "encoding/json"
 
 type MessageType interface {
-	json.RawMessage | JoinPayload | PartPayload
+	json.RawMessage | JoinPayload | PartPayload | BroadcastMePayload
 }
 
 type Message[D MessageType] struct {
@@ -17,4 +17,9 @@ type JoinPayload struct {
 
 type PartPayload struct {
 	Name string `json:"name"`
+}
+
+type BroadcastMePayload struct {
+	Name    string `json:"name"`
+	Channel string `json:"channel"`
 }


### PR DESCRIPTION
Adds `broadcast_me` check and `emote_update` payload. 

There isn't a good way to test if the implementation sends `broadcast_me`, so here, the `emote_update` message is only sent if the `broadcast_me` message is received. This way, if a client forgets to send the `broadcast_me` message, it won't get the `emote_update` message and hopefully fail the test.