### PR TITLE
feat: add optional TCP listener and `/echo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add optional TCP listener (second argument). (#120)
+- Add `/echo` handler. (#120)
+
 ## v1.0.8
 
 - Include `server.crt` and `server.key` in releases. (#113)

--- a/cmd/server/.gitignore
+++ b/cmd/server/.gitignore
@@ -1,1 +1,2 @@
 server
+server.exe

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,26 +12,30 @@ import (
 )
 
 func main() {
-	err := run()
-	if err != nil {
-		log.Fatal(err)
+	e1, e2 := run()
+	if e1 != nil {
+		log.Fatal(e1)
+	}
+	if e2 != nil {
+		log.Fatal(e2)
 	}
 }
 
 // run starts a http.Server for the passed in address
 // with all requests handled by echoServer.
-func run() error {
+func run() (error, error) {
 	if len(os.Args) < 2 {
-		return errors.New("please provide an address to listen on as the first argument")
+		return errors.New("please provide an address to listen on as the first argument"), nil
 	}
 
-	l, err := net.Listen("tcp", os.Args[1])
+	tlsListener, err := net.Listen("tcp", os.Args[1])
 	if err != nil {
-		return err
+		return err, nil
 	}
-	log.Printf("listening on http://%v", l.Addr())
 
-	s := &http.Server{
+	log.Printf("listening on https://%v", tlsListener.Addr())
+
+	tlsServer := &http.Server{
 		Handler:      server{},
 		ReadTimeout:  time.Second * 10,
 		WriteTimeout: time.Second * 10,
@@ -41,8 +45,28 @@ func run() error {
 	keyFile := "server.key"
 	errc := make(chan error, 1)
 	go func() {
-		errc <- s.ServeTLS(l, certFile, keyFile)
+		errc <- tlsServer.ServeTLS(tlsListener, certFile, keyFile)
 	}()
+
+	var tcpServer *http.Server
+	if len(os.Args) >= 3 {
+		tcpListener, err := net.Listen("tcp", os.Args[2])
+		if err != nil {
+			return err, nil
+		}
+
+		log.Printf("listening on http://%v", tcpListener.Addr())
+
+		tcpServer = &http.Server{
+			Handler:      server{},
+			ReadTimeout:  time.Second * 10,
+			WriteTimeout: time.Second * 10,
+		}
+
+		go func() {
+			errc <- tcpServer.Serve(tcpListener)
+		}()
+	}
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, os.Interrupt)
@@ -56,5 +80,9 @@ func run() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	return s.Shutdown(ctx)
+	var tcpErr error
+	if tcpServer != nil {
+		tcpErr = tcpServer.Shutdown(ctx)
+	}
+	return tlsServer.Shutdown(ctx), tcpErr
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -35,6 +35,8 @@ func (s server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		routes.AuthenticationRequired(c, r)
 	case "/automod-held":
 		routes.AutomodHeld(c, r)
+	case "/echo":
+		routes.Echo(c, r)
 	case "/liveupdates/sub-unsub":
 		liveupdates.BasicSubUnsub(c, r)
 	case "/liveupdates/seventv/all-events":

--- a/internal/routes/echo.go
+++ b/internal/routes/echo.go
@@ -1,0 +1,30 @@
+package routes
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/coder/websocket"
+)
+
+func Echo(c *websocket.Conn, r *http.Request) {
+	for {
+		ty, data, err := c.Read(r.Context())
+		if err != nil {
+			log.Printf("Failed to read from %v: %v", r.RemoteAddr, err)
+			break
+		}
+		if string(data) == "/CLOSE" {
+			err = c.Close(websocket.StatusNormalClosure, "Close command")
+			if err != nil {
+				log.Printf("Failed to gracefully close connection %v: %v", r.RemoteAddr, err)
+			}
+			break
+		}
+		err = c.Write(r.Context(), ty, data)
+		if err != nil {
+			log.Printf("Failed to write to %v: %v", r.RemoteAddr, err)
+			break
+		}
+	}
+}


### PR DESCRIPTION
For https://github.com/Chatterino/chatterino2/pull/6076.

- Adds an optional TCP listener (for backwards compatibility). The address is the second argument: `./server 127.0.0.1:9050 127.0.0.1:9052`.
- Adds an echo endpoint `/echo` which repeats the messages and exits upon receiving `/CLOSE`.