### PR TITLE
feat(echo): add `/HEADER <name>` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `/HEADER <name>` command to the `/echo` handler. (#121)
+
 ## v1.0.9
 
 - Add optional TCP listener (second argument). (#120)

--- a/internal/routes/echo.go
+++ b/internal/routes/echo.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/coder/websocket"
 )
@@ -14,13 +15,19 @@ func Echo(c *websocket.Conn, r *http.Request) {
 			log.Printf("Failed to read from %v: %v", r.RemoteAddr, err)
 			break
 		}
-		if string(data) == "/CLOSE" {
+		strData := string(data)
+
+		if strData == "/CLOSE" {
 			err = c.Close(websocket.StatusNormalClosure, "Close command")
 			if err != nil {
 				log.Printf("Failed to gracefully close connection %v: %v", r.RemoteAddr, err)
 			}
 			break
 		}
+		if strings.HasPrefix(strData, "/HEADER ") {
+			data = []byte(r.Header.Get(strings.TrimPrefix(strData, "/HEADER ")))
+		}
+
 		err = c.Write(r.Context(), ty, data)
 		if err != nil {
 			log.Printf("Failed to write to %v: %v", r.RemoteAddr, err)


### PR DESCRIPTION
To test if headers are set correctly in https://github.com/Chatterino/chatterino2/pull/6076, a way to return them is needed. `/HEADER <name>` seems like the most straight forward way for this. If a header doesn't exist, an empty string is returned.