### PR TITLE
feat: add `/URL` to `/echo` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `/URL` command to the `/echo` handler. (#126)
+
 ## v1.0.11
 
 - Add default TCP listener param to dockerfile. (#124)

--- a/internal/routes/echo.go
+++ b/internal/routes/echo.go
@@ -26,6 +26,8 @@ func Echo(c *websocket.Conn, r *http.Request) {
 		}
 		if strings.HasPrefix(strData, "/HEADER ") {
 			data = []byte(r.Header.Get(strings.TrimPrefix(strData, "/HEADER ")))
+		} else if strData == "/URL" {
+			data = []byte(r.URL.String())
 		}
 
 		err = c.Write(r.Context(), ty, data)


### PR DESCRIPTION
Needed for https://github.com/Chatterino/chatterino2/pull/6141.

Note that this only contains the path and query:

> For server requests, the URL is parsed from the URI supplied on the Request-Line as stored in RequestURI. For  most requests, fields other than Path and RawQuery will be empty. (See [RFC 7230, Section 5.3](https://rfc-editor.org/rfc/rfc7230.html#section-5.3))
https://pkg.go.dev/net/http#Request.URL